### PR TITLE
Add support for recieving input from a redirection and files

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,14 +35,6 @@ func main() {
 		return
 	}
 
-	//TODO: add support for text files from CLI args
-	//dirty hack from https://stackoverflow.com/a/41999124
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeNamedPipe) == 0 {
-		fmt.Println("Haste Client can only be used in pipes!")
-		return
-	}
-
 	stdinBuffer, _ := ioutil.ReadAll(os.Stdin)
 	content := string(stdinBuffer)
 	uploadToHaste(*hasteURL, content)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,24 @@ func main() {
 		return
 	}
 
+	if len(os.Args) == 1 {
+		readStdin()
+	} else {
+		for _, file := range(os.Args[1:]) {
+			if file == "-" {
+				readStdin()
+			} else {
+				data, err := ioutil.ReadFile(file)
+				if err != nil {
+					log.Fatalf("%s: Failed reading data from file: %s\n", os.Args[0], err)
+				}
+				uploadToHaste(*hasteURL, string(data))
+			}
+		}
+	}
+}
+
+func readStdin() {
 	stdinBuffer, _ := ioutil.ReadAll(os.Stdin)
 	content := string(stdinBuffer)
 	uploadToHaste(*hasteURL, content)


### PR DESCRIPTION
This will allow you to upload a file by doing `haste <foo` instead of `cat foo | haste`.

EDIT: I also added support for passing files as arguments, so you can do `haste file1 file2 file3 ...` and it'll give you a link for each file. It also follows the same convention of other utilities such as `cat` and `sed` where you can give the filename `-` to read from standard input which lets you do something like this: `echo Hello World | haste file1 - file2`