### PR TITLE
Fix selection of different host & url parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 )
@@ -18,11 +19,11 @@ const (
 
 var (
 	printVersion = flag.Bool("v", false, "Shows program version")
-	returnRaw    = flag.Bool("r", false, "Returns link to raw content")
+	returnRaw    = flag.Bool("r", false, "Makes returned link point to raw content")
 	hasteURL     = flag.String("d", "https://haste.zneix.eu", "Hastebin server's URL to which data will be uploaded")
 
-	apiRoute   = "/documents"
-	httpClient = &http.Client{
+	uploadAPIRoute = "/documents"
+	httpClient     = &http.Client{
 		Timeout: 10 * time.Second,
 	}
 )
@@ -30,22 +31,30 @@ var (
 func readStdin() {
 	stdinBuffer, _ := io.ReadAll(os.Stdin)
 	content := string(stdinBuffer)
-	uploadToHaste(*hasteURL, content)
+	uploadToHaste(content)
 }
 
-func uploadToHaste(url, data string) {
+func uploadToHaste(data string) {
 	type HasteResponseData struct {
 		Key string `json:"key,omitempty"`
 	}
 
-	req, err := http.NewRequest("POST", *hasteURL+apiRoute, bytes.NewBufferString(data))
+	// Parse the request URL and append the API route for uploading text
+	destination, err := url.ParseRequestURI(*hasteURL)
+	if err != nil {
+		log.Fatal("Error while parsing destination URL (full URL with a protocol scheme is required):", err)
+		return
+	}
+	uploadEndpoint := destination.JoinPath(uploadAPIRoute)
+
+	// Create & Send the request
+	req, err := http.NewRequest("POST", uploadEndpoint.String(), bytes.NewBufferString(data))
 	if err != nil {
 		log.Fatal("Error while creating HTTP request:", err)
 		return
 	}
 	req.Header.Set("User-Agent", fmt.Sprintf("haste-client/%s", version))
 
-	// Send the request
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		log.Fatal("Error while performing the request:", err)
@@ -53,12 +62,13 @@ func uploadToHaste(url, data string) {
 	}
 	defer resp.Body.Close()
 
+	// Error out if request wasn't handled correctly by the remote server (which is indicated by the response status)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
 		log.Fatalln("Failed to upload data, server responded with", resp.StatusCode)
 		return
 	}
 
-	// Error out if the invite isn't found or something else went wrong with the request
+	// Read & process the received response data
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln("Error while reading response:", err)
@@ -71,37 +81,40 @@ func uploadToHaste(url, data string) {
 		return
 	}
 
-	var finalURL = url
+	// Handle returning raw text if it is desired so and respond with uploaded text's URL
 	if *returnRaw {
-		finalURL += "/raw"
+		destination = destination.JoinPath("/raw")
 	}
-	finalURL += "/" + jsonResponse.Key
-
-	fmt.Println(finalURL)
+	fmt.Println(destination.JoinPath(jsonResponse.Key).String())
 }
 
 func main() {
 	// Handle CLI arguments
 	flag.Parse()
 
+	// Print version and quit
 	if *printVersion {
 		fmt.Printf("Haste Client %s\n", version)
 		return
 	}
 
-	if len(os.Args) == 1 {
+	// Upload from stdin if there's no file name provided
+	if len(flag.Args()) < 1 {
 		readStdin()
-	} else {
-		for _, file := range os.Args[1:] {
-			if file == "-" {
-				readStdin()
-			} else {
-				data, err := os.ReadFile(file)
-				if err != nil {
-					log.Fatalf("%s: Failed reading data from file: %s\n", os.Args[0], err)
-				}
-				uploadToHaste(*hasteURL, string(data))
-			}
+		return
+	}
+
+	// Otherwise, if arguments are provided use them as file names to upload
+	for _, file := range flag.Args() {
+		if file == "-" {
+			readStdin()
+			continue
 		}
+
+		data, err := os.ReadFile(file)
+		if err != nil {
+			log.Fatalf("%s: Failed reading data from file: %s\n", os.Args[0], err)
+		}
+		uploadToHaste(string(data))
 	}
 }


### PR DESCRIPTION
Switched to using `flag.Args()` which accounts for command line options such as `-d` being used to specify flag options instead of trying to treat those as files with `os.Args`.
Also switched to using `net/url`'s URL object to handle link creation a bit better.

Fixes #7
